### PR TITLE
fix issue with reloading proteus::helpers in rails app

### DIFF
--- a/app/helpers/proteus/helpers.rb
+++ b/app/helpers/proteus/helpers.rb
@@ -27,7 +27,7 @@ module Proteus
       # probably hook into the compile_assets_fallback option or something
 
       puts "Checking for domain #{request.host.downcase.strip}"
-      domain = WhitelabeledDomain.find_by(host: request.host.downcase.strip)
+      domain = ::Proteus::WhitelabeledDomain.find_by(host: request.host.downcase.strip)
 
       if domain.present?
         puts "Domain found"


### PR DESCRIPTION
based on advice from here: https://stackoverflow.com/questions/29636334/a-copy-of-xxx-has-been-removed-from-the-module-tree-but-is-still-active

Somehow when rails autoloads modules, we kept getting this error `A copy of Proteus::Helpers has been removed from the module tree but is still active!` in the development environment. These changes fix that for me at least.